### PR TITLE
Start Python refactor skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,13 @@ evaluation/datasets/**/*.pdf
 evaluation/datasets/**/*.jpeg
 evaluation/datasets/**/*.jpg
 evaluation/datasets/**/*.pgm
-
 *.pkl
+!pdffigures2_python/models/region_classifier_model.pkl
+
+venv/
+.pytest_cache/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # PDFFigures 2.0
+
+This repository includes the original Scala implementation and a new Python refactor under `pdffigures2_python`. The Python code requires **Python 3.8+** and dependencies listed in `requirements.txt`. Use a virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
 PDFFigures 2.0 is a Scala based project built to extract figures, captions, tables and section titles from
 scholarly documents, with a strong focus on documents from the domain of computer science.
 See our [paper](http://ai2-website.s3.amazonaws.com/publications/pdf2.0.pdf) for more details.
@@ -172,5 +181,19 @@ from the header in figures on the first page, but there is probably a way to
 relax this assumption to resolve this issue.
 
 
+
 ## Contact
 Christopher Clark, chrisc@allenai.org
+
+## Python Usage
+Run the refactored Python version via:
+
+```bash
+python -m pdffigures2_python.cli path/to/file.pdf -d output/data
+```
+
+To run tests:
+
+```bash
+pytest
+```

--- a/pdffigures2_python/__init__.py
+++ b/pdffigures2_python/__init__.py
@@ -1,0 +1,15 @@
+"""Python refactor of PDFFigures2."""
+
+__all__ = [
+    "cli",
+    "pdf_parser",
+    "text_extraction",
+    "formatting",
+    "document_layout",
+    "caption_detector",
+    "caption_builder",
+    "graphic_extractor",
+    "region_classifier",
+    "figure_detector",
+    "figure_renderer",
+]

--- a/pdffigures2_python/caption_builder.py
+++ b/pdffigures2_python/caption_builder.py
@@ -1,0 +1,16 @@
+"""Assemble multi-line captions."""
+from typing import List
+
+from .text_extraction import TextLine
+
+
+def build_caption(start: TextLine, lines: List[TextLine]) -> TextLine:
+    """Join subsequent lines that belong to the same caption."""
+    text = [start.text]
+    bottom = start.y + start.height
+    for line in lines:
+        if line.y > start.y and line.y - bottom < 2 and line.font_size == start.font_size:
+            text.append(line.text)
+            bottom = line.y + line.height
+    joined = " ".join(text)
+    return TextLine(start.x, start.y, start.width, bottom - start.y, joined, start.font_size)

--- a/pdffigures2_python/caption_detector.py
+++ b/pdffigures2_python/caption_detector.py
@@ -1,0 +1,18 @@
+"""Caption detection logic."""
+import re
+from typing import List
+
+from .document_layout import DocumentStats
+from .text_extraction import TextLine
+
+CAPTION_PATTERNS = [re.compile(r"^(figure|fig|table)\b", re.IGNORECASE)]
+
+
+def find_captions(lines: List[TextLine], stats: DocumentStats) -> List[TextLine]:
+    """Return lines that look like captions."""
+    results = []
+    for line in lines:
+        if any(pat.match(line.text) for pat in CAPTION_PATTERNS):
+            if line.font_size <= stats.median_font_size:
+                results.append(line)
+    return results

--- a/pdffigures2_python/cli.py
+++ b/pdffigures2_python/cli.py
@@ -1,0 +1,21 @@
+"""Command line interface for the Python port of PDFFigures2."""
+from argparse import ArgumentParser
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Extract figures and captions from PDFs")
+    parser.add_argument("pdf", help="Input PDF file")
+    parser.add_argument("-d", "--data-prefix", required=True, help="Output JSON prefix")
+    parser.add_argument("-m", "--image-prefix", help="Optional image output prefix")
+    return parser
+
+
+def main(argv=None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    # TODO: invoke pipeline once modules are implemented
+    print(f"Would process {args.pdf} -> {args.data_prefix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pdffigures2_python/document_layout.py
+++ b/pdffigures2_python/document_layout.py
@@ -1,0 +1,19 @@
+"""Document layout statistics."""
+from dataclasses import dataclass
+from statistics import mean
+from typing import List
+
+from .text_extraction import TextLine
+
+
+@dataclass
+class DocumentStats:
+    avg_font_size: float
+    median_font_size: float
+
+
+def compute_layout_stats(lines: List[TextLine]) -> DocumentStats:
+    sizes = [l.font_size for l in lines]
+    avg = mean(sizes) if sizes else 0
+    median = sorted(sizes)[len(sizes)//2] if sizes else 0
+    return DocumentStats(avg, median)

--- a/pdffigures2_python/figure_detector.py
+++ b/pdffigures2_python/figure_detector.py
@@ -1,0 +1,38 @@
+"""Combine captions and graphics into figure regions."""
+from typing import List
+
+from .caption_builder import build_caption
+from .caption_detector import find_captions
+from .document_layout import compute_layout_stats
+from .graphic_extractor import extract_graphics
+from .text_extraction import TextLine
+
+from .text_extraction import extract_text_lines
+
+def detect_figures(page) -> List[dict]:
+    lines = extract_text_lines(page)
+    stats = compute_layout_stats(lines)
+    captions = [build_caption(c, lines) for c in find_captions(lines, stats)]
+    graphics = extract_graphics(page)
+    figures = []
+    for caption in captions:
+        figures.append({
+            "page": page.number,
+            "caption": caption.text,
+            "captionBoundary": {
+                "x": caption.x,
+                "y": caption.y,
+                "width": caption.width,
+                "height": caption.height,
+            },
+            "regionBoundary": {
+                "x": caption.x,
+                "y": caption.y - 100,
+                "width": caption.width,
+                "height": caption.height + 100,
+            },
+            "figureType": "Figure",
+            "name": "",
+            "text": "",
+        })
+    return figures

--- a/pdffigures2_python/figure_renderer.py
+++ b/pdffigures2_python/figure_renderer.py
@@ -1,0 +1,20 @@
+"""Render detected figures to image files."""
+from pathlib import Path
+from typing import List, Dict
+
+import fitz
+
+
+def save_figure_images(figures: List[Dict], pdf_path: str, prefix: str) -> None:
+    doc = fitz.open(pdf_path)
+    for idx, fig in enumerate(figures):
+        page = doc.load_page(fig["page"])
+        rect = fitz.Rect(
+            fig["regionBoundary"]["x"],
+            fig["regionBoundary"]["y"],
+            fig["regionBoundary"]["x"] + fig["regionBoundary"]["width"],
+            fig["regionBoundary"]["y"] + fig["regionBoundary"]["height"],
+        )
+        pix = page.get_pixmap(clip=rect)
+        out = Path(f"{prefix}_{idx}.png")
+        pix.save(out)

--- a/pdffigures2_python/formatting.py
+++ b/pdffigures2_python/formatting.py
@@ -1,0 +1,15 @@
+"""Utilities for cleaning extracted text."""
+from typing import List
+
+from .text_extraction import TextLine
+
+
+def filter_text_blocks(text_blocks: List[TextLine]) -> List[TextLine]:
+    """Remove headers, footers, and page numbers."""
+    cleaned = []
+    for line in text_blocks:
+        lower = line.text.lower().strip()
+        if lower.isdigit():
+            continue
+        cleaned.append(line)
+    return cleaned

--- a/pdffigures2_python/graphic_extractor.py
+++ b/pdffigures2_python/graphic_extractor.py
@@ -1,0 +1,18 @@
+"""Extract images and drawings from a page."""
+from typing import List, Tuple
+
+import fitz
+
+
+BBox = Tuple[float, float, float, float]
+
+
+def extract_graphics(page: fitz.Page) -> List[BBox]:
+    boxes = []
+    for img in page.get_images(full=True):
+        for rect in page.get_image_rects(img[0]):
+            boxes.append((rect.x0, rect.y0, rect.x1, rect.y1))
+    for drawing in page.get_drawings():
+        rect = drawing[0]
+        boxes.append((rect.x0, rect.y0, rect.x1, rect.y1))
+    return boxes

--- a/pdffigures2_python/pdf_parser.py
+++ b/pdffigures2_python/pdf_parser.py
@@ -1,0 +1,10 @@
+"""PDF parsing utilities using PyMuPDF."""
+from typing import List
+
+import fitz
+
+
+def parse_pdf(path: str) -> List[fitz.Page]:
+    """Open a PDF and return list of pages."""
+    doc = fitz.open(path)
+    return [page for page in doc]

--- a/pdffigures2_python/region_classifier.py
+++ b/pdffigures2_python/region_classifier.py
@@ -1,0 +1,26 @@
+"""Classify text lines using a pre-trained model."""
+from typing import List
+
+import joblib
+
+from .document_layout import DocumentStats
+from .text_extraction import TextLine
+
+_model = None
+
+
+def _load_model():
+    global _model
+    if _model is None:
+        _model = joblib.load(
+            __import__("pkgutil").get_data(__package__, "models/region_classifier_model.pkl")
+        )
+    return _model
+
+
+def classify_text_lines(lines: List[TextLine], stats: DocumentStats) -> List[str]:
+    """Return labels for each line (e.g., 'BodyText' or 'Other')."""
+    model = _load_model()
+    # Placeholder feature: font size ratio
+    features = [[line.font_size / stats.avg_font_size if stats.avg_font_size else 0] for line in lines]
+    return model.predict(features)  # type: ignore

--- a/pdffigures2_python/text_extraction.py
+++ b/pdffigures2_python/text_extraction.py
@@ -1,0 +1,25 @@
+"""Text extraction helpers."""
+from dataclasses import dataclass
+from typing import List
+
+import fitz
+
+
+@dataclass
+class TextLine:
+    x: float
+    y: float
+    width: float
+    height: float
+    text: str
+    font_size: float
+
+
+def extract_text_lines(page: fitz.Page) -> List[TextLine]:
+    """Return text lines from a page."""
+    lines: List[TextLine] = []
+    for b in page.get_text("blocks"):
+        x0, y0, x1, y1, text, *_ = b
+        if text.strip():
+            lines.append(TextLine(x0, y0, x1 - x0, y1 - y0, text, y1 - y0))
+    return lines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyMuPDF
+scikit-learn
+Pillow
+pytest

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pdffigures2_python."""

--- a/tests/test_caption_detection.py
+++ b/tests/test_caption_detection.py
@@ -1,0 +1,9 @@
+from pdffigures2_python import caption_detector, document_layout
+from pdffigures2_python.text_extraction import TextLine
+
+
+def test_simple_caption_line():
+    line = TextLine(0, 0, 100, 10, "Figure 1: Test", 8)
+    stats = document_layout.DocumentStats(avg_font_size=12, median_font_size=12)
+    captions = caption_detector.find_captions([line], stats)
+    assert len(captions) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,5 @@
+import os
+
+
+def test_sample_pdf_exists():
+    assert os.path.exists(os.path.join(os.path.dirname(__file__), "sample_papers", "test1.pdf"))

--- a/tests/test_region_classification.py
+++ b/tests/test_region_classification.py
@@ -1,0 +1,14 @@
+from pdffigures2_python import region_classifier, document_layout
+from pdffigures2_python.text_extraction import TextLine
+
+
+def test_model_load(monkeypatch):
+    class DummyModel:
+        def predict(self, X):
+            return ["BodyText" for _ in X]
+
+    monkeypatch.setattr(region_classifier, "_load_model", lambda: DummyModel())
+    line = TextLine(0, 0, 100, 10, "Sample", 12)
+    stats = document_layout.DocumentStats(avg_font_size=12, median_font_size=12)
+    labels = region_classifier.classify_text_lines([line], stats)
+    assert labels == ["BodyText"]


### PR DESCRIPTION
## Summary
- start Python package `pdffigures2_python`
- add placeholder modules for parsing, caption detection, and CLI
- add basic tests and sample PDF
- document Python setup and usage in README
- add requirements and gitignore entries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets', 'fitz', 'joblib')*